### PR TITLE
[Bugfix] Fix the ipc bug caused by incorrect tensor management and update example_remote_copy

### DIFF
--- a/examples/distributed/example_remote_copy.py
+++ b/examples/distributed/example_remote_copy.py
@@ -4,12 +4,12 @@ import argparse
 import torch
 import torch.distributed as dist
 import torch.multiprocessing
-from tilelang.distributed.utils import init_dist, create_dist_tensor
+from tilelang.distributed.utils import init_dist, create_dist_tensor, create_tensor
 
 tilelang.disable_cache()
 
 
-def kernel_(M, N, num_rank, block_M, block_N, threads):
+def kernel_(M, N, num_rank, block_M, threads):
 
     @T.prim_func
     def main(
@@ -18,11 +18,12 @@ def kernel_(M, N, num_rank, block_M, block_N, threads):
             rank: T.Tensor((1), "int32"),
             meta_data: T.Tensor((1, num_rank), "uint64", buffer_type="meta_data"),
     ):
-        with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=threads) as (bx, by):
+        with T.Kernel(T.ceildiv(M, block_M), threads=threads) as bid:
+            #TODO(ipc): Add work partition among warps and vectorized copy
             T.remote_copy(
-                src=T.address_of(src[0, 0]),
-                dst=T.address_of(dst[0, 0]),
-                size=M * N,
+                src=T.address_of(src[bid * block_M, 0]),
+                dst=T.address_of(dst[bid * block_M, 0]),
+                size=block_M * N,
                 dst_pe=rank[0] ^ 1,
                 unroll_factor=4)
 
@@ -32,18 +33,17 @@ def kernel_(M, N, num_rank, block_M, block_N, threads):
 def main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     M, N = args.M, args.N
     BLOCK_M = 128
-    BLOCK_N = 256
-    threads = 256
+    threads = 128
 
     rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
     src = torch.randn(M, N, device="cuda", dtype=torch.float32)
-    dst = torch.empty(M, N, device="cuda", dtype=torch.float32)
+    dst = create_tensor([M, N], torch.float32)
     rank_tensor = torch.tensor([local_rank], device="cuda", dtype=torch.int32)
     buffer_ptrs_gpu = create_dist_tensor(local_rank, num_local_ranks, dst, rank,
                                          group).reshape(1, num_local_ranks)
 
-    kernel = tilelang.compile(kernel_(M, N, num_ranks, BLOCK_M, BLOCK_N, threads))
-    if local_rank == 0:
+    kernel = tilelang.compile(kernel_(M, N, num_ranks, BLOCK_M, threads))
+    if local_rank == 0 and args.print_source:
         print(kernel.get_kernel_source())
 
     torch.cuda.synchronize()
@@ -70,8 +70,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--num-processes', type=int, default=2, help='Number of processes to spawn (default: 2)')
-    parser.add_argument('--M', type=int, default=8192, help='M dimension')
-    parser.add_argument('--N', type=int, default=8192, help='N dimension')
+    parser.add_argument('--M', type=int, default=256, help='M dimension')
+    parser.add_argument('--N', type=int, default=256, help='N dimension')
+    parser.add_argument(
+        '--print-source', action='store_true', help='Print the source code of the kernel')
     args = parser.parse_args()
     num_processes = args.num_processes
+
     torch.multiprocessing.spawn(main, args=(num_processes, args), nprocs=num_processes)

--- a/tilelang/distributed/common/ipc_ext.cpp
+++ b/tilelang/distributed/common/ipc_ext.cpp
@@ -3,101 +3,130 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
+#include <torch/python.h>
 #include <torch/types.h>
-#include <tuple>
 #include <vector>
+#include <ATen/ops/from_blob.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAFunctions.h>
 
 namespace py = pybind11;
 
-class EPException: public std::exception {
+class EPException : public std::exception {
 private:
-    std::string message = {};
+  std::string message = {};
 
 public:
-    explicit EPException(const char *name, const char* file, const int line, const std::string& error) {
-        message = std::string("Failed: ") + name + " error " + file + ":" + std::to_string(line) + " '" + error + "'";
-    }
+  explicit EPException(const char *name, const char *file, const int line,
+                       const std::string &error) {
+    message = std::string("Failed: ") + name + " error " + file + ":" +
+              std::to_string(line) + " '" + error + "'";
+  }
 
-    const char *what() const noexcept override { return message.c_str(); }
+  const char *what() const noexcept override { return message.c_str(); }
 };
 
-
 #ifndef EP_HOST_ASSERT
-#define EP_HOST_ASSERT(cond) \
-do { \
-    if (not (cond)) { \
-        throw EPException("Assertion", __FILE__, __LINE__, #cond); \
-    } \
-} while (0)
+#define EP_HOST_ASSERT(cond)                                                   \
+  do {                                                                         \
+    if (not(cond)) {                                                           \
+      throw EPException("Assertion", __FILE__, __LINE__, #cond);               \
+    }                                                                          \
+  } while (0)
 #endif
-
 
 #ifndef CUDA_CHECK
-#define CUDA_CHECK(cmd) \
-do { \
-    cudaError_t e = (cmd); \
-    if (e != cudaSuccess) { \
-        throw EPException("CUDA", __FILE__, __LINE__, cudaGetErrorString(e)); \
-    } \
-} while (0)
+#define CUDA_CHECK(cmd)                                                        \
+  do {                                                                         \
+    cudaError_t e = (cmd);                                                     \
+    if (e != cudaSuccess) {                                                    \
+      throw EPException("CUDA", __FILE__, __LINE__, cudaGetErrorString(e));    \
+    }                                                                          \
+  } while (0)
 #endif
 
-pybind11::bytearray create_ipc_handle(void* ptr) {
-    cudaIpcMemHandle_t handle;
-    cudaIpcGetMemHandle(&handle, ptr);
-    return {handle.reserved, CUDA_IPC_HANDLE_SIZE};
+torch::Tensor create_tensor(const std::vector<int64_t> &shape,
+                            c10::ScalarType dtype) {
+  auto current_device = c10::cuda::current_device();
+  auto option_gpu =
+      at::TensorOptions(at::kCUDA).dtype(dtype).device_index(current_device);
+  auto size = torch::elementSize(dtype) *
+              std::accumulate(shape.begin(), shape.end(), (size_t)1,
+                              std::multiplies<>());
+  CUDA_CHECK(cudaDeviceSynchronize());
+  void *ptr = nullptr;
+  CUDA_CHECK(cudaMalloc(&ptr, size));
+  return at::from_blob(
+      ptr, shape, [=](void *ptr) { CUDA_CHECK(cudaFree(ptr)); }, option_gpu);
+}
+
+pybind11::bytearray create_ipc_handle(void *ptr) {
+  cudaIpcMemHandle_t *handle =
+      (cudaIpcMemHandle_t *)malloc(sizeof(cudaIpcMemHandle_t));
+  cudaIpcGetMemHandle(handle, ptr);
+  pybind11::bytearray result = {handle->reserved, CUDA_IPC_HANDLE_SIZE};
+  return result;
 }
 
 void sync_ipc_handles(
-    int rank,
-    const std::vector<int> &device_ids,
-    void** buffer_ptrs_gpu,
+    int rank, const std::vector<int> &device_ids, void **buffer_ptrs_gpu,
     const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles,
-    const std::optional<pybind11::bytearray>& root_unique_id_opt
-) {
-    // TODO: Support inter-node case
-    int rdma_rank = 0;
-    int num_nvl_ranks = device_ids.size();
-    cudaIpcMemHandle_t ipc_handles[device_ids.size()];
-    // buffer_ptrs is a pointer on host and points to the address on device
-    void* buffer_ptrs[device_ids.size()];
-    // EP_HOST_ASSERT(num_ranks == device_ids.size());
-    EP_HOST_ASSERT(device_ids.size() == all_gathered_handles.size());
-    for (int i = 0, offset = rdma_rank * num_nvl_ranks; i < num_nvl_ranks; ++ i) {
-        EP_HOST_ASSERT(all_gathered_handles[offset + i].has_value());
-        auto handle_str = std::string(all_gathered_handles[offset + i].value());
-        EP_HOST_ASSERT(handle_str.size() == CUDA_IPC_HANDLE_SIZE);
-        if (offset + i != rank) {
-            std::memcpy(ipc_handles[i].reserved, handle_str.c_str(), CUDA_IPC_HANDLE_SIZE);
-            CUDA_CHECK(cudaIpcOpenMemHandle(&buffer_ptrs[i], ipc_handles[i], cudaIpcMemLazyEnablePeerAccess));
-        } 
+    const std::optional<pybind11::bytearray> &root_unique_id_opt) {
+  // TODO: Support inter-node case
+  int rdma_rank = 0;
+  int num_nvl_ranks = device_ids.size();
+  cudaIpcMemHandle_t ipc_handles[device_ids.size()];
+  // buffer_ptrs is a pointer on host and points to the address on device
+  void *buffer_ptrs[device_ids.size()];
+  // EP_HOST_ASSERT(num_ranks == device_ids.size());
+  EP_HOST_ASSERT(device_ids.size() == all_gathered_handles.size());
+  for (int i = 0, offset = rdma_rank * num_nvl_ranks; i < num_nvl_ranks; ++i) {
+    EP_HOST_ASSERT(all_gathered_handles[offset + i].has_value());
+    auto handle_str = std::string(all_gathered_handles[offset + i].value());
+    EP_HOST_ASSERT(handle_str.size() == CUDA_IPC_HANDLE_SIZE);
+    if (offset + i != rank) {
+      std::memcpy(ipc_handles[i].reserved, handle_str.c_str(),
+                  CUDA_IPC_HANDLE_SIZE);
+      CUDA_CHECK(cudaIpcOpenMemHandle(&buffer_ptrs[i], ipc_handles[i],
+                                      cudaIpcMemLazyEnablePeerAccess));
     }
+  }
 
-    // Copy all buffer and barrier signal pointers to GPU
-    CUDA_CHECK(cudaMemcpy(buffer_ptrs_gpu, buffer_ptrs, sizeof(void*) * device_ids.size(), cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaDeviceSynchronize());
+  // Copy all buffer and barrier signal pointers to GPU
+  CUDA_CHECK(cudaMemcpy(buffer_ptrs_gpu, buffer_ptrs,
+                        sizeof(void *) * device_ids.size(),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaDeviceSynchronize());
 }
 
 PYBIND11_MODULE(ipc_ext, m) {
-    m.def("create_ipc_handle", [](uintptr_t ptr_value) {
-        void* ptr = reinterpret_cast<void*>(ptr_value);
-        return create_ipc_handle(ptr);
-    }, py::arg("ptr_value"));
+  m.def(
+      "_create_tensor",
+      [](const std::vector<int64_t> &shape, const py::object &dtype) {
+        return create_tensor(shape,
+                             torch::python::detail::py_object_to_dtype(dtype));
+      },
+      py::arg("shape"), py::arg("dtype"));
 
-    m.def("sync_ipc_handles", [](
-        int rank,
-        const std::vector<int>& device_ids,
-        uintptr_t buffer_ptrs_gpu_addr,
-        const std::vector<std::optional<py::bytearray>>& all_gathered_handles,
-        const std::optional<py::bytearray>& root_unique_id_opt
-    ) {
-        void** buffer_ptrs_gpu = reinterpret_cast<void**>(buffer_ptrs_gpu_addr);
-        sync_ipc_handles(rank, device_ids, buffer_ptrs_gpu, all_gathered_handles, root_unique_id_opt);
-    }, 
-    py::arg("rank"), 
-    py::arg("device_ids"),
-    py::arg("buffer_ptrs_gpu_addr"),
-    py::arg("all_gathered_handles"),
-    py::arg("root_unique_id_opt")
-    ); 
+  m.def(
+      "_create_ipc_handle",
+      [](uintptr_t ptr_value) {
+        void *ptr = reinterpret_cast<void *>(ptr_value);
+        return create_ipc_handle(ptr);
+      },
+      py::arg("ptr_value"));
+
+  m.def(
+      "_sync_ipc_handles",
+      [](int rank, const std::vector<int> &device_ids,
+         uintptr_t buffer_ptrs_gpu_addr,
+         const std::vector<std::optional<py::bytearray>> &all_gathered_handles,
+         const std::optional<py::bytearray> &root_unique_id_opt) {
+        void **buffer_ptrs_gpu =
+            reinterpret_cast<void **>(buffer_ptrs_gpu_addr);
+        sync_ipc_handles(rank, device_ids, buffer_ptrs_gpu,
+                         all_gathered_handles, root_unique_id_opt);
+      },
+      py::arg("rank"), py::arg("device_ids"), py::arg("buffer_ptrs_gpu_addr"),
+      py::arg("all_gathered_handles"), py::arg("root_unique_id_opt"));
 }

--- a/tilelang/distributed/utils.py
+++ b/tilelang/distributed/utils.py
@@ -1,14 +1,12 @@
 import torch
 import torch.distributed as dist
-import datetime
 import os
 import inspect
 from typing import List, Union, Tuple, Callable, Sequence
 from contextlib import contextmanager
 from cuda import cuda, cudart
 import ctypes
-import os
-from tilelang.distributed.common.ipc_ext import create_ipc_handle, sync_ipc_handles
+from tilelang.distributed.common.ipc_ext import _create_ipc_handle, _sync_ipc_handles, _create_tensor
 
 dtype_map = {
     "bfloat16": torch.bfloat16,
@@ -46,36 +44,15 @@ def init_dist(local_rank: int, num_local_ranks: int):
         list(range(num_local_ranks * num_nodes)))
 
 
-def init_distributed(return_tp_group=False, init_nvshmem=False):
-    WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
-    RANK = int(os.environ.get("RANK", 0))
-    LOCAL_RANK = int(os.environ.get("LOCAL_RANK", 0))
-
-    torch.distributed.init_process_group(
-        backend="nccl",
-        world_size=WORLD_SIZE,
-        rank=RANK,
-        timeout=datetime.timedelta(seconds=1800),
-    )
-    torch.cuda.set_device(LOCAL_RANK)
-    assert torch.distributed.is_initialized()
-    TP_GROUP = torch.distributed.new_group(ranks=list(range(WORLD_SIZE)), backend="nccl")
-
-    torch.cuda.synchronize()
-    if init_nvshmem:
-        import pynvshmem
-        pynvshmem.init_nvshmem_by_uniqueid(TP_GROUP)
-
-    if return_tp_group:
-        return WORLD_SIZE, RANK, LOCAL_RANK, TP_GROUP
-    else:
-        return WORLD_SIZE, RANK, LOCAL_RANK
+def create_tensor(shape: List[int], dtype: torch.dtype):
+    # NOTE(wt): We discovered that IPC only works with tensors explicitly allocated by `cudaMalloc` somehow.
+    return _create_tensor(shape, dtype)
 
 
 # IPC related functions
 def get_local_ipc_handle(data: torch.Tensor):
     p = ctypes.c_void_p(data.data_ptr())
-    handle = create_ipc_handle(p.value)
+    handle = _create_ipc_handle(p.value)
     return handle
 
 
@@ -96,8 +73,8 @@ def create_dist_tensor(local_rank: int, num_local_ranks: int, data: torch.Tensor
     local_ipc_handle = get_local_ipc_handle(data)
     dist.all_gather_object(ipc_handles, local_ipc_handle, group)
     buffer_ptrs_gpu = torch.empty(group.size(), dtype=torch.uint64, device="cuda")
-    sync_ipc_handles(rank, device_ids,
-                     ctypes.c_void_p(buffer_ptrs_gpu.data_ptr()).value, ipc_handles, None)
+    _sync_ipc_handles(rank, device_ids,
+                      ctypes.c_void_p(buffer_ptrs_gpu.data_ptr()).value, ipc_handles, None)
     return buffer_ptrs_gpu
 
 


### PR DESCRIPTION
- Updated `utils.py` to include a new `create_tensor` function for explicit CUDA memory allocation, enhancing IPC compatibility.

- Update example_remote_copy

- Fix lint
