### PR TITLE
[Feat][Doc] Enhance TileLang with NVSHMEM support and build system improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,30 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_compile_definitions(tilelang_static PRIVATE "TVM_LOG_DEBUG")
 endif()
 
+set(ALLOC_CUDA_EXT_DIR ${PROJECT_SOURCE_DIR}/tilelang/utils/cpp)
+add_custom_target(
+  build_alloc_cuda_ext ALL
+  COMMAND
+    ${Python_EXECUTABLE} setup.py build_ext --inplace
+  WORKING_DIRECTORY
+    ${ALLOC_CUDA_EXT_DIR}
+  COMMENT
+    "Building alloc_cuda PyTorch extension (in-place)"
+)
+add_dependencies(tilelang build_alloc_cuda_ext)
+
+set(IPC_EXT_DIR ${PROJECT_SOURCE_DIR}/tilelang/distributed/common)
+add_custom_target(
+  build_ipc_ext ALL
+  COMMAND
+    ${Python_EXECUTABLE} setup.py build_ext --inplace
+  WORKING_DIRECTORY
+    ${IPC_EXT_DIR}
+  COMMENT
+    "Building ipc_ext PyTorch extension (in-place)"
+)
+add_dependencies(tilelang build_ipc_ext)
+
 # Building tvm_cython modules
 if(NOT DEFINED TVM_PREBUILD_PATH)
   add_dependencies(tilelang tvm_cython)

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -6,7 +6,7 @@
 
 - **Operating System**: Linux
 - **Python Version**: >= 3.7
-- **CUDA Version**: >= 10.0
+- **CUDA Version**: >= 12.1
 - **LLVM**: < 20 if you are using the bundled TVM submodule
 
 We currently provide three methods to install **TileScale**:

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -1,37 +1,5 @@
 # Installation Guide
 
-## Installing with pip
-
-**Prerequisites for installation via wheel or PyPI:**
-
-- **Operating System**: Ubuntu 20.04 or later
-- **Python Version**: >= 3.8
-- **CUDA Version**: >= 11.0
-
-The easiest way to install **tile-lang** is directly from PyPI using pip. To install the latest version, run the following command in your terminal:
-
-```bash
-pip install tilelang
-```
-
-Alternatively, you may choose to install **tile-lang** using prebuilt packages available on the Release Page:
-
-```bash
-pip install tilelang-0.0.0.dev0+ubuntu.20.4.cu120-py3-none-any.whl
-```
-
-To install the latest version of **tile-lang** from the GitHub repository, you can run the following command:
-
-```bash
-pip install git+https://github.com/tile-ai/tilelang.git
-```
-
-After installing **tile-lang**, you can verify the installation by running:
-
-```bash
-python -c "import tilelang; print(tilelang.__version__)"
-```
-
 ## Building from Source
 
 **Prerequisites for building from source:**
@@ -41,34 +9,7 @@ python -c "import tilelang; print(tilelang.__version__)"
 - **CUDA Version**: >= 10.0
 - **LLVM**: < 20 if you are using the bundled TVM submodule
 
-We recommend using a Docker container with the necessary dependencies to build **tile-lang** from source. You can use the following command to run a Docker container with the required dependencies:
-
-```bash
-docker run --gpus all -it --rm --ipc=host nvcr.io/nvidia/pytorch:23.01-py3
-```
-
-To build and install **tile-lang** directly from source, follow these steps. This process requires certain pre-requisites from Apache TVM, which can be installed on Ubuntu/Debian-based systems using the following commands:
-
-```bash
-apt-get update
-apt-get install -y python3 python3-dev python3-setuptools gcc zlib1g-dev build-essential cmake libedit-dev
-```
-
-After installing the prerequisites, you can clone the **tile-lang** repository and install it using pip:
-
-```bash
-git clone --recursive https://github.com/tile-ai/tilelang.git
-cd tilelang
-pip install .  # Please be patient, this may take some time.
-```
-
-If you want to install **tile-lang** in development mode, you can run the following command:
-
-```bash
-pip install -e .
-```
-
-We currently provide three methods to install **tile-lang**:
+We currently provide three methods to install **TileScale**:
 
 1. [Install from Source (using your own TVM installation)](#install-method-1)
 2. [Install from Source (using the bundled TVM submodule)](#install-method-2)
@@ -83,8 +24,8 @@ If you already have a compatible TVM installation, follow these steps:
 1. **Clone the Repository**:
 
 ```bash
-git clone --recursive https://github.com/tile-ai/tilelang
-cd tilelang
+git clone --recursive https://github.com/tile-ai/tilescale
+cd tilescale
 ```
 
 **Note**: Use the `--recursive` flag to include necessary submodules.
@@ -119,8 +60,8 @@ If you prefer to use the built-in TVM version, follow these instructions:
 1. **Clone the Repository**:
 
 ```bash
-git clone --recursive https://github.com/tile-ai/tilelang
-cd tilelang
+git clone --recursive https://github.com/tile-ai/tilescale
+cd tilescale
 ```
 
 **Note**: Ensure the `--recursive` flag is included to fetch submodules.
@@ -159,8 +100,8 @@ For a simplified installation, use the provided script:
 1. **Clone the Repository**:
 
 ```bash
-git clone --recursive https://github.com/tile-ai/tilelang
-cd tilelang
+git clone --recursive https://github.com/tile-ai/tilescale
+cd tilescale
 ```
 
 2. **Run the Installation Script**:
@@ -170,13 +111,25 @@ bash install_cuda.sh
 # or bash `install_amd.sh` if you want to enable ROCm runtime
 ```
 
-## Install with Nightly Version
 
-For users who want access to the latest features and improvements before official releases, we provide nightly builds of **tile-lang**.
+## To use NVSHMEM APIs
+
+Before running the examples using NVSHMEM APIs (e.g., [example_allgather.py](../../examples/distributed/example_allgather.py)), you need to build NVSHMEM library for device-side code generation.
+
+```bash 
+export NVSHMEM_SRC="your_custom_nvshmem_dir" # default to 3rdparty/nvshmem_src
+cd tilelang/distributed
+source build_nvshmem.sh
+```
+You also need to install the `pynvshmem` package, which provides wrapped host-side Python API for NVSHMEM.
 
 ```bash
-pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu121/
-# or pip install tilelang --find-links https://tile-ai.github.io/whl/nightly/cu121/
+cd ./pynvshmem
+python setup.py install
+export LD_LIBRARY_PATH="$NVSHMEM_SRC/build/src/lib:$LD_LIBRARY_PATH"
 ```
 
-> **Note:** Nightly builds contain the most recent code changes but may be less stable than official releases. They're ideal for testing new features or if you need a specific bugfix that hasn't been released yet.
+Then you can test python import:
+```bash
+python -c "import pynvshmem"
+```

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -117,6 +117,7 @@ bash install_cuda.sh
 Before running the examples using NVSHMEM APIs (e.g., [example_allgather.py](../../examples/distributed/example_allgather.py)), you need to build NVSHMEM library for device-side code generation.
 
 ```bash 
+pip install mpich
 export NVSHMEM_SRC="your_custom_nvshmem_dir" # default to 3rdparty/nvshmem_src
 cd tilelang/distributed
 source build_nvshmem.sh

--- a/docs/get_started/run_example.md
+++ b/docs/get_started/run_example.md
@@ -1,0 +1,21 @@
+# Run Examples
+
+## Examples without NVSHMEM
+
+Before running, enable TileLang’s distributed mode:
+
+```bash
+export TILELANG_USE_DISTRIBUTED=1 
+```
+Then start an example directly with Python:
+```bash
+python examples/distributed/example_push_warp.py 
+```
+
+## Examples using NVSHMEM APIs
+
+Use the provided launcher `tilelang/distributed/launch.sh` to start programs that use the NVSHMEM API. For example, to run with 2 GPUs:
+```bash
+GPUS=2 ./tilelang/distributed/launch.sh examples/distributed/example_allgather.py
+```
+You can change GPUS to the number of local GPUs you want to use. The launcher will set the required environment variables and invoke `torch.distributed.run`.

--- a/examples/distributed/example_pull_warp.py
+++ b/examples/distributed/example_pull_warp.py
@@ -37,7 +37,7 @@ def kernel_(M, num_rank, block_M, threads):
 
 
 def main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
-    M = args.M
+    M = args.M if args else 65536
     BLOCK_M = 4096
     threads = 128
     assert num_local_ranks == 2, "this example only supports 2 ranks copying to each other"

--- a/examples/distributed/example_push_warp.py
+++ b/examples/distributed/example_push_warp.py
@@ -37,7 +37,7 @@ def kernel_(M, num_rank, block_M, threads):
 
 
 def main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
-    M = args.M
+    M = args.M if args else 65536
     BLOCK_M = 4096
     threads = 128
     assert num_local_ranks == 2, "this example only supports 2 ranks copying to each other"

--- a/examples/distributed/test_pull_warp.py
+++ b/examples/distributed/test_pull_warp.py
@@ -1,0 +1,15 @@
+import tilelang.testing
+import torch
+import torch.multiprocessing
+
+import example_pull_warp
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_example_pull_warp():
+    torch.multiprocessing.spawn(example_pull_warp.main, args=(2, None), nprocs=2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/examples/distributed/test_push_warp.py
+++ b/examples/distributed/test_push_warp.py
@@ -1,0 +1,15 @@
+import tilelang.testing
+import torch
+import torch.multiprocessing
+
+import example_push_warp
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_example_push_warp():
+    torch.multiprocessing.spawn(example_push_warp.main, args=(2, None), nprocs=2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/distributed/launch.sh
+++ b/tilelang/distributed/launch.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:~/.local/lib/
 
+export TILELANG_USE_NVSHMEM=1  # enable TileLang distributed mode
 export TILELANG_USE_DISTRIBUTED=1  # enable TileLang distributed mode
 export NVSHMEM_BOOTSTRAP_MPI_PLUGIN=nvshmem_bootstrap_torch.so
 export NVSHMEM_DISABLE_CUDA_VMM=1  # moving from cpp to shell
@@ -32,7 +33,8 @@ export NVSHMEM_IB_GID_INDEX=3
 memcheck=${MEMCHECK:=0}  # set env var. `MEMCHECK` to 1 to enable memory check via compute-sanitizer
 # This is especially useful for debugging memory issues, e.g. CUDA misalignment errors and TMA stuff.
 
-CMD="torchrun \
+PYTHON_EXEC="$(which python)"
+CMD="${PYTHON_EXEC} -m torch.distributed.run \
   --node_rank=${node_rank} \
   --nproc_per_node=${nproc_per_node} \
   --nnodes=${nnodes} \

--- a/tilelang/distributed/pynvshmem/python/pynvshmem/__init__.py
+++ b/tilelang/distributed/pynvshmem/python/pynvshmem/__init__.py
@@ -1,7 +1,8 @@
 import sys
 import torch
 import torch.distributed
-from cuda import cuda, cudart
+from cuda.bindings import driver as cuda
+from cuda.bindings import runtime as cudart
 from typing import Optional
 from enum import IntEnum
 

--- a/tilelang/distributed/utils.py
+++ b/tilelang/distributed/utils.py
@@ -5,7 +5,8 @@ import os
 import inspect
 from typing import List, Union, Tuple, Callable, Sequence
 from contextlib import contextmanager
-from cuda import cuda, cudart
+from cuda.bindings import driver as cuda
+from cuda.bindings import runtime as cudart
 import ctypes
 from tilelang.distributed.common.ipc_ext import _create_ipc_handle, _sync_ipc_handles, _create_tensor
 

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -211,6 +211,7 @@ class Environment:
 
     # Distributed settings
     USE_DISTRIBUTED = EnvVar("TILELANG_USE_DISTRIBUTED", "0").get().lower() in ("1", "true", "on")
+    USE_NVSHMEM = EnvVar("TILELANG_USE_NVSHMEM", "0").get().lower() in ("1", "true", "on")
     if USE_DISTRIBUTED:
         if EnvVar("NVSHMEM_SRC", None).get() is not None:
             NVSHMEM_SRC = EnvVar("NVSHMEM_SRC", None).get()

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -8,7 +8,7 @@ from libc.stdlib cimport malloc, free
 from tvm import tir
 from tilelang.utils.tensor import map_torch_type
 from tilelang.env import env
-if env.USE_DISTRIBUTED:
+if env.USE_NVSHMEM:
     import pynvshmem
 
 cdef class CythonKernelWrapper:
@@ -195,7 +195,7 @@ cdef class CythonKernelWrapper:
                         f"Cannot create output tensor (name={param_name}) - 0-dimensional tensors are not supported. "
                         f"Expected shape: {shape}"
                     )
-                if env.USE_DISTRIBUTED:
+                if env.USE_NVSHMEM:
                     tensor = pynvshmem.nvshmem_create_tensor(shape, dtype)
                 else:
                     tensor = torch.empty(*shape, dtype=dtype, device=device)

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -135,7 +135,7 @@ class LibraryGenerator(object):
         command += [
             "-I" + env.TILELANG_TEMPLATE_PATH,
         ]
-        if env.USE_DISTRIBUTED:
+        if env.USE_NVSHMEM:
             assert env.NVSHMEM_INCLUDE_DIR is not None, "env.NVSHMEM_INCLUDE_DIR is not set"
             assert env.NVSHMEM_LIB_PATH is not None, "env.NVSHMEM_LIB_PATH is not set"
             command += ["-diag-suppress=20013"]

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -39,7 +39,9 @@ extern "C" int init() {{
     {0}
     return 0;
 }}
+"""
 
+PREDEF_INIT_TABLE_FUNC = """
 extern "C" int init_table(const void* host_table, size_t n) {{
     if (error_buf) error_buf[0] = '\\0';
 
@@ -239,7 +241,8 @@ class TLCUDASourceWrapper(object):
         self.block_info: Union[List[int], Dict] = [1, 1, 1]
         self.grid_info: Union[List[int], Dict] = [1, 1, 1]
         self.tma_descriptor_args: Optional[Dict] = None
-        self.use_nvshmem = env.USE_DISTRIBUTED
+        self.use_distributed = env.USE_DISTRIBUTED
+        self.use_nvshmem = env.USE_NVSHMEM
         self.l2_persistent_map: Optional[Dict[str, Dict]] = {}
         self.parse_source_information()
         self.srcpath: Optional[str] = None
@@ -546,6 +549,8 @@ class TLCUDASourceWrapper(object):
         nvshmem_init_str = "nvshmem_init();\n\t" if self.use_nvshmem else ""
         # Format the initialization function using the call_str
         init_funcs = PREDEF_INIT_FUNC.format(nvshmem_init_str + call_str)
+        if self.use_distributed:
+            init_funcs += PREDEF_INIT_TABLE_FUNC
         return init_funcs
 
     def update_lib_code(self, code: str):

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -21,9 +21,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-if env.USE_NVSHMEM:
-    import pynvshmem
-
 
 @dataclass
 class Profiler:
@@ -86,7 +83,9 @@ class Profiler:
         TP_GROUP = torch.distributed.new_group(ranks=list(range(WORLD_SIZE)), backend="nccl")
 
         torch.cuda.synchronize()
-        pynvshmem.init_nvshmem_by_uniqueid(TP_GROUP)
+        if env.USE_NVSHMEM:
+            import pynvshmem
+            pynvshmem.init_nvshmem_by_uniqueid(TP_GROUP)
 
     def _get_inputs(self, with_output=False):
         ins = []

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -21,11 +21,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-if env.USE_DISTRIBUTED:
+if env.USE_NVSHMEM:
     import pynvshmem
-    logger.info("Using distributed profiler")
-else:
-    logger.info("Not using distributed profiler")
 
 
 @dataclass

--- a/tilelang/utils/allocator.py
+++ b/tilelang/utils/allocator.py
@@ -174,6 +174,13 @@ class BaseAllocator:
 
         bytes_alloc = _align_up(bytes_needed, self._align)
 
+        current_offset = int(self._ptr.value) - int(self._base_ptr.value)
+        if current_offset + bytes_alloc > self.size:
+            bytes_available = self.size - current_offset
+            raise MemoryError(f"Allocation failed: Requesting {bytes_alloc} bytes, but only "
+                              f"{bytes_available} bytes are available in the pre-allocated buffer "
+                              f"(total size: {self.size} bytes).")
+
         if not isinstance(self._ptr, ctypes.c_void_p):
             raise TypeError("self._ptr must be ctypes.c_void_p")
         cur_ptr_val = int(self._ptr.value)


### PR DESCRIPTION
- Added support for NVSHMEM in the environment configuration, enabling distributed memory operations.
- Introduced custom build targets for CUDA extensions in the CMake configuration.
- Updated installation documentation to reflect the new repository name and NVSHMEM usage.
- Created a new guide for running examples with and without NVSHMEM.
- Refactored various components to utilize NVSHMEM for distributed tensor management and memory allocation.
- Improved error handling in the allocator for better memory management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional NVSHMEM runtime flag and improved CUDA init for distributed host-table setup.
  - Launcher now runs distributed jobs via the Python module runner and enables NVSHMEM mode.

- Bug Fixes
  - Allocator pre-allocation boundary checks to prevent GPU memory overruns with clear errors.

- Documentation
  - Installation guide reorganized into three methods, renamed to TileScale, and includes NVSHMEM setup.
  - New guide for running distributed examples (with and without NVSHMEM).

- Chores
  - Build now auto-builds required PyTorch extensions as part of the main build.

- Tests
  - Added CUDA-guarded distributed example tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->