### PR TITLE
[BugFix] Fix port conflict in ci.yml pytest  

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         if [ "${#OTHER_TESTS[@]}" -gt 0 ]; then
           echo "Running non-distributed examples:"
           printf '%s\n' "${OTHER_TESTS[@]}"
-          python -m pytest -n 1 "${OTHER_TESTS[@]}" -v -r fE
+          python -m pytest -n 4 "${OTHER_TESTS[@]}" -v -r fE
         else
           echo "No non-distributed example tests found."
         fi
@@ -152,7 +152,7 @@ jobs:
         if [ "${#OTHER_TESTS[@]}" -gt 0 ]; then
           echo "Running non-distributed tests:"
           printf '%s\n' "${OTHER_TESTS[@]}"
-          python -m pytest -n 1 "${OTHER_TESTS[@]}" -v -r fE
+          python -m pytest -n 4 "${OTHER_TESTS[@]}" -v -r fE
         else
           echo "No non-distributed tests found under testing/python."
         fi


### PR DESCRIPTION
In the original test cases, using pytest -n 4 for parallel execution caused port conflicts in multiple distributed test cases. This issue was resolved by switching to sequential execution to avoid port conflicts. Change "pytest -n 4" to "pytest -n 1"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI configuration updated to include an additional runner type and to reduce test parallelism across workflows.
  * All test and example runs now execute with fewer parallel workers.
  * No changes to product functionality or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->