### PR TITLE
[Example] Update AG-GEMM example

### DIFF
--- a/examples/distributed/example_allgather_gemm_overlapped.py
+++ b/examples/distributed/example_allgather_gemm_overlapped.py
@@ -22,19 +22,14 @@ os.environ['NCCL_DEBUG'] = 'WARN'  # silence NCCL log
 
 
 @tilelang.jit(pass_configs={"tl.disable_warp_specialized": True, "tl.disable_tma_lower": True})
-def set_signal_kernel(local_rank,
-                    rank,
-                    num_ranks,
-                    threads):
+def set_signal_kernel(local_rank, num_local_ranks, threads):
 
     @T.prim_func
-    def _set_signal_kernel(
-            signal_buffer: T.Tensor((num_ranks), "uint32"),
-    ):
-        with T.Kernel(1, threads=threads) as (block_id):
+    def _set_signal_kernel(signal_buffer: T.Tensor((num_local_ranks), "uint32"),):
+        with T.Kernel(1, threads=threads):
             tx = T.get_thread_binding(0)
-            if tx < num_ranks:
-                if tx == rank:
+            if tx < num_local_ranks:
+                if tx == local_rank:
                     signal_buffer[tx] = 1
                 else:
                     signal_buffer[tx] = 0
@@ -46,27 +41,32 @@ def set_signal_kernel(local_rank,
 def gemm_kernel(M,
                 N,
                 K,
-                num_rank,
                 local_rank,
+                num_local_rank,
                 block_M,
                 block_N,
                 block_K,
                 threads,
+                persistent=False,
                 dtype="float16",
                 accum_dtype="float"):
 
-    M_per_rank = T.ceildiv(M, num_rank)
+    sm_num = driver.get_num_sms()
+    m_blocks = T.ceildiv(M, block_M)
+    n_blocks = T.ceildiv(N // num_local_rank, block_N)
+    waves = T.ceildiv(m_blocks * n_blocks, sm_num)
+    M_per_rank = T.ceildiv(M, num_local_rank)
     GROUP_SIZE_M = 8
 
     @T.prim_func
     def main(
             A: T.Tensor((M, K), dtype),
-            B: T.Tensor((K, N // num_rank), dtype),
-            signal_buffer: T.Tensor((num_rank), "uint32"),
-            C: T.Tensor((M, N // num_rank), dtype),
+            B: T.Tensor((K, N // num_local_rank), dtype),
+            signal_buffer: T.Tensor((num_local_rank), "uint32"),
+            C: T.Tensor((M, N // num_local_rank), dtype),
     ):
         with T.Kernel(
-                T.ceildiv(M, block_M) * T.ceildiv(N // num_rank, block_N),
+                T.ceildiv(M, block_M) * T.ceildiv(N // num_local_rank, block_N),
                 threads=threads) as (bid):
             A_shared = T.alloc_shared((block_M, block_K), dtype)
             B_shared = T.alloc_shared((block_K, block_N), dtype)
@@ -74,7 +74,7 @@ def gemm_kernel(M,
             C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
 
             num_pid_m = T.ceildiv(M, block_M)
-            num_pid_n = T.ceildiv(N // num_rank, block_N)
+            num_pid_n = T.ceildiv(N // num_local_rank, block_N)
             num_pid_in_group = GROUP_SIZE_M * num_pid_n
             group_id = bid // num_pid_in_group
             first_pid_m = group_id * GROUP_SIZE_M
@@ -100,54 +100,94 @@ def gemm_kernel(M,
             T.copy(C_local, C_shared)
             T.copy(C_shared, C[pid_m * block_M, pid_n * block_N])
 
-    return main
+    @T.prim_func
+    def main_persistent(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((K, N // num_local_rank), dtype),
+            signal_buffer: T.Tensor((num_local_rank), "uint32"),
+            C: T.Tensor((M, N // num_local_rank), dtype),
+    ):
+        with T.Kernel(sm_num, threads=threads) as (bid):
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_K, block_N), dtype)
+            C_shared = T.alloc_shared((block_M, block_N), dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            for w in T.serial(waves):
+                tile_id = bid + w * sm_num
+                num_pid_m = T.ceildiv(M, block_M)
+                num_pid_n = T.ceildiv(N // num_local_rank, block_N)
+                num_pid_in_group = GROUP_SIZE_M * num_pid_n
+                group_id = tile_id // num_pid_in_group
+                first_pid_m = group_id * GROUP_SIZE_M
+                group_size_m = T.min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+                pid_m_ = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+                pid_n_ = (tile_id % num_pid_in_group) // group_size_m
+
+                # threadblock swizzle
+                #  no stream-k support. only split by m x n
+                m_offset = M_per_rank * local_rank
+                pid_m_offset = T.ceildiv(m_offset, block_M)
+                pid_m = (pid_m_ + pid_m_offset) % num_pid_m
+                pid_n = pid_n_
+
+                if pid_n_ * block_N < (N // num_local_rank) and pid_m_ * block_M < M:
+                    tid = T.get_thread_binding(0)
+                    T.clear(C_local)
+                    if tid == 0:
+                        T.wait_eq(signal_buffer[pid_m * block_M // M_per_rank], 1)
+                    for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=3):
+                        T.copy(A[pid_m * block_M, k * block_K], A_shared)
+                        T.copy(B[k * block_K, pid_n * block_N], B_shared)
+                        T.gemm(A_shared, B_shared, C_local)
+                    T.copy(C_local, C_shared)
+                    T.copy(C_shared, C[pid_m * block_M, pid_n * block_N])
+
+    return main if not persistent else main_persistent
 
 
 def cp_engine_producer_all_gather_full_mesh_pull(
-    local_tensor,
     ag_buffer,
     signal_buffer,
     M_per_rank,
-    N,
     signal_target,
-    rank,
+    local_rank,
     local_world_size,
-    world_size,
     intranode_ag_stream,
 ):
-    rank_orders = [(rank + i) % local_world_size for i in range(local_world_size)]
+    rank_orders = [(local_rank + i) % local_world_size for i in range(local_world_size)]
 
     with torch.cuda.stream(intranode_ag_stream):
         for src_rank in rank_orders:
-            if src_rank == rank:
+            if src_rank == local_rank:
                 continue
-            dst = ag_buffer[rank][src_rank * M_per_rank:(src_rank + 1) * M_per_rank, :]
+            dst = ag_buffer[local_rank][src_rank * M_per_rank:(src_rank + 1) * M_per_rank, :]
             src = ag_buffer[src_rank][src_rank * M_per_rank:(src_rank + 1) * M_per_rank, :]
             dst.copy_(src)
 
             (err,) = cuda.cuStreamWriteValue32(
                 intranode_ag_stream.cuda_stream,
-                signal_buffer[rank][src_rank].data_ptr(),
+                signal_buffer[local_rank][src_rank].data_ptr(),
                 signal_target,
                 cuda.CUstreamWriteValue_flags.CU_STREAM_WRITE_VALUE_DEFAULT,
             )
 
 
-def ag_gemm_op(A, B, C, ag_buffer, signal_buffer, sync_buffer, M_per_rank, N, signal_target, rank,
-               group, local_world_size, world_size, set_signal_kernel, gemm_kernel, gemm_stream,
-               ag_stream):
+def ag_gemm_op(A, B, C, ag_buffer, signal_buffer, M_per_rank, N, signal_target, local_rank,
+               local_world_size, set_signal_kernel, gemm_kernel, gemm_stream, ag_stream):
 
     with torch.cuda.stream(gemm_stream):
-        set_signal_kernel(signal_buffer[rank], stream=gemm_stream.cuda_stream)
+        set_signal_kernel(signal_buffer[local_rank], stream=gemm_stream.cuda_stream)
 
     ag_stream.wait_stream(gemm_stream)
 
-    cp_engine_producer_all_gather_full_mesh_pull(A, ag_buffer, signal_buffer, M_per_rank, N,
-                                                 signal_target, rank, local_world_size, world_size,
+    cp_engine_producer_all_gather_full_mesh_pull(ag_buffer, signal_buffer, M_per_rank,
+                                                 signal_target, local_rank, local_world_size,
                                                  ag_stream)
 
     with torch.cuda.stream(gemm_stream):
-        gemm_kernel(ag_buffer[rank], B, signal_buffer[rank], C, stream=gemm_stream.cuda_stream)
+        gemm_kernel(
+            ag_buffer[local_rank], B, signal_buffer[local_rank], C, stream=gemm_stream.cuda_stream)
 
     gemm_stream.wait_stream(ag_stream)
     current_stream = torch.cuda.current_stream()
@@ -171,6 +211,7 @@ def main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     M = args.M if args else 8192
     N = args.N if args else 8192
     K = args.K if args else 8192
+    persistent = args.persistent
     M_per_rank = M // num_local_ranks
     N_per_rank = N // num_local_ranks
 
@@ -180,6 +221,7 @@ def main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     threads = 256
 
     rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    assert rank == local_rank and num_ranks == num_local_ranks, "only support single node for now"
     allocator = tilelang.get_allocator(
         size=2**30,
         device="cuda",
@@ -187,12 +229,12 @@ def main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         local_rank=local_rank,
         num_local_ranks=num_local_ranks,
         group=group)
-    gemm_func = gemm_kernel(M, N, K, num_ranks, rank, BLOCK_M, BLOCK_N, BLOCK_K, threads)
+    gemm_func = gemm_kernel(M, N, K, local_rank, num_local_ranks, BLOCK_M, BLOCK_N, BLOCK_K,
+                            threads, persistent)
     set_signal_func = set_signal_kernel(
         local_rank=local_rank,
-        rank=local_rank,
-        num_ranks=num_ranks,
-        threads=128,
+        num_local_ranks=num_local_ranks,
+        threads=32,
     )
     gemm_func.initialize(allocator=allocator)
     set_signal_func.initialize(allocator=allocator)
@@ -208,18 +250,16 @@ def main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                                     torch.uint32,
                                     allocator=allocator,
                                     return_peers=True)
-    signal_buffer[rank].fill_(0)  # check if needed
-    sync_buffer = tilelang.tensor((3 * num_ranks,), torch.uint32, allocator=allocator)
 
     gemm_stream = torch.cuda.Stream()
     ag_stream = torch.cuda.Stream(priority=-1)
     signal_target = 1
-    
+
     dist.barrier()
 
-    tilelang_C = ag_gemm_op(A, B, C, ag_buffer, signal_buffer, sync_buffer, M_per_rank, K,
-                            signal_target, rank, group, num_local_ranks, num_local_ranks,
-                            set_signal_func, gemm_func, gemm_stream, ag_stream)
+    tilelang_C = ag_gemm_op(A, B, C, ag_buffer, signal_buffer, M_per_rank, K, signal_target,
+                            local_rank, num_local_ranks, set_signal_func, gemm_func, gemm_stream,
+                            ag_stream)
 
     torch_ag_buffer = torch.empty([M, K], dtype=dtype, device="cuda")
     torch_C = torch_ag_gemm(group, A, B, torch_ag_buffer)
@@ -230,10 +270,10 @@ def main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         print(f"rank {local_rank} check failed.❌")
         print(f"torch_C: {torch_C}, tilelang_C: {tilelang_C}")
 
-    tl_out, tl_t = perf_fn(
-        lambda: ag_gemm_op(A, B, C, ag_buffer, signal_buffer, sync_buffer, M_per_rank, K,
-                           signal_target, rank, group, num_local_ranks, num_local_ranks,
-                           set_signal_func, gemm_func, gemm_stream, ag_stream),
+    _, tl_t = perf_fn(
+        lambda:
+        ag_gemm_op(A, B, C, ag_buffer, signal_buffer, M_per_rank, K, signal_target, local_rank,
+                   num_local_ranks, set_signal_func, gemm_func, gemm_stream, ag_stream),
         warmup=5,
         rep=10)
 
@@ -251,6 +291,7 @@ if __name__ == "__main__":
     parser.add_argument('--M', type=int, default=8192, help='M dimension')
     parser.add_argument('--N', type=int, default=28672, help='N dimension')
     parser.add_argument('--K', type=int, default=8192, help='K dimension')
+    parser.add_argument('--persistent', action='store_true', help='Use persistent kernel')
     args = parser.parse_args()
     num_processes = args.num_processes
 


### PR DESCRIPTION
This pull request refactors the distributed allgather GEMM overlapped example to simplify intra-node signaling, improve kernel flexibility, and streamline function interfaces. The main changes include replacing the previous copy-and-barrier kernel with a lightweight signal-setting kernel, adding support for persistent GEMM kernels, and updating function arguments and variable naming for clarity and correctness.

**Kernel and Signaling Refactor:**
* Replaced the `copy_and_barrier_all_intra_node_kernel` with a new `set_signal_kernel`, removing unnecessary copy and barrier logic and focusing only on signal setting for intra-node synchronization. (`examples/distributed/example_allgather_gemm_overlapped.py`)
* Updated GEMM kernel logic to support both standard and persistent execution modes, controlled via a new `--persistent` CLI flag. Persistent mode uses a new `main_persistent` kernel for improved performance in some scenarios. (`examples/distributed/example_allgather_gemm_overlapped.py`) [[1]](diffhunk://#diff-645b7a7b139dd8d2d2729e028cebca4796ecdca11417d8068be69529dcb649bfL143-R190) [[2]](diffhunk://#diff-645b7a7b139dd8d2d2729e028cebca4796ecdca11417d8068be69529dcb649bfR294)

**Function Interface and Variable Naming Updates:**
* Refactored function signatures and variable names throughout the code to consistently use `local_rank` and `num_local_ranks` instead of ambiguous `rank` and `num_ranks`, clarifying the single-node focus and improving code readability. (`examples/distributed/example_allgather_gemm_overlapped.py`) [[1]](diffhunk://#diff-645b7a7b139dd8d2d2729e028cebca4796ecdca11417d8068be69529dcb649bfL143-R190) [[2]](diffhunk://#diff-645b7a7b139dd8d2d2729e028cebca4796ecdca11417d8068be69529dcb649bfR224-R262)
* Simplified and updated the `ag_gemm_op` and `cp_engine_producer_all_gather_full_mesh_pull` functions to match the new signaling and kernel invocation logic, removing unused arguments and streamlining the data flow. (`examples/distributed/example_allgather_gemm_overlapped.py`)

**Main Routine and CLI Improvements:**
* Updated the main routine to initialize and use the new kernels and buffers, removed unused synchronization logic, and added an assertion to ensure single-node operation. (`examples/distributed/example_allgather_gemm_overlapped.py`) [[1]](diffhunk://#diff-645b7a7b139dd8d2d2729e028cebca4796ecdca11417d8068be69529dcb649bfR224-R262) [[2]](diffhunk://#diff-645b7a7b139dd8d2d2729e028cebca4796ecdca11417d8068be69529dcb649bfR214)
* Added a `--persistent` command-line argument to allow users to select persistent kernel execution. (`examples/distributed/example_allgather_gemm_overlapped.py`)